### PR TITLE
Add publisher script

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to you under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -e
+
+gem install bundler:2.1.2
+bundle config set path 'vendor/bundle'
+bundle install 
+bundle exec jekyll clean --source .
+bundle exec jekyll build --source .
+
+COMMIT_HASH=`git rev-parse HEAD`
+git checkout asf-site
+#git pull --rebase
+rm -rf content
+mv target content
+git add content
+echo "Publishing changes from master branch $COMMIT_HASH"
+git commit -a -m "Publishing from $COMMIT_HASH"
+echo " "
+echo "==================================================================="
+echo "You are now on the asf-site branch with your new changes committed."
+echo " git push the 'asf-site' branch upstream to update the live site."
+echo "If you want to preview the content run a simple http server pointed"
+echo " at the content directory. This can be accomplished like this:"
+echo " python3 -m http.server --directory content 8080" 
+echo "==================================================================="
+echo " "
+
+set +e


### PR DESCRIPTION
Running this script will generate the static website content and make a commit in the asf-site branch that is linking to the commit that it generated from.  This also takes care of installing all the ruby build dependencies in a vendor folder so they do not have to be install system wide.

I have an example of a orphaned asf-site branch as well that I would recommend we use as a starting branch.  Someone would need to force it over the existing asf-site branch that is based on master.

So in short to see how this works, clone my fork checkout this publish branch and run the "./publish.sh" script.