### PR TITLE
Add .asf.yaml file used in other Apache NuttX repos

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,0 +1,22 @@
+github:
+  description: "Apache NuttX Website"
+  homepage: https://nuttx.apache.org/
+  features:
+    # Enable issues managment
+    issues: true
+    # Enable project for project managment boards
+    projects: true
+  labels:
+    - nuttx
+    - rtos
+    - embedded
+    - real-time
+    - mcu
+    - microcontroller
+  enabled_merge_buttons:
+    # enable squash button:
+    squash:  true
+    # enable merge button:
+    merge:   true
+    # enable rebase button:
+    rebase:  true


### PR DESCRIPTION
Lets at least be consistent in the features we have enabled until we have a proper flow defined.