### PR TITLE
Only publish site on push to master.  Build for all PR

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,24 +2,23 @@ name: CI
 
 on:
   pull_request:
-    branches: [ master ]
-    types: [closed]
+  push:
+    branches:
+      - master
 
 jobs:
   build:
     runs-on: ubuntu-latest
-
-    if: github.event.pull_request.merged == true
     steps:
     - uses: actions/checkout@v2
     - run: |
         git fetch --prune --unshallow
 
-    - name: Intall tools
+    - name: Install tools
       run: |
         sudo apt-get -y install rubygems ruby-dev zlib1g-dev
 
-    - name: Run publish.sh
+    - name: Build Site
       run: |
         export GEM_HOME=$HOME/.gem
         export PATH=$PATH:$GEM_HOME/bin
@@ -28,4 +27,8 @@ jobs:
         git config --global user.name $username
         git config --global user.email $email
         ./publish.sh
+
+    - name: Publish Site
+      if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+      run: |
         git push origin asf-site:asf-site


### PR DESCRIPTION
This resolves an issue where the GitHub action could not perform the push action against the repository.  Now the site is built for all pull requests, but only is published on the push to the master branch.  Note that the push to master event happens when the pull request is merged.

This restriction is because you do not want the PR context to be able to have write access to the repository as outlined here:
https://help.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token#permissions-for-the-github_token