### PR TITLE
Add Mateusz Szafoni to the roster as a commiter

### DIFF
--- a/_data/contributors.yml
+++ b/_data/contributors.yml
@@ -89,6 +89,12 @@
   role: PPMC, Committer
   org:
 
+- name: Mateusz Szafoni
+  apacheId: raiden00pl
+  githubId: raiden00pl
+  role: Committer
+  org:
+
 - name: Mohammad Asif Siddiqui
   apacheId: asifdxtreme
   githubId: asifdxtreme


### PR DESCRIPTION
## Summary
Adding the entry to the roster for Mateusz Szafoni