### PR TITLE
Update wiki namespace mapping

### DIFF
--- a/_data/project.yml
+++ b/_data/project.yml
@@ -47,7 +47,7 @@ commits_list_archive_mailarchive: https://www.mail-archive.com/commits@nuttx.apa
 commits_list_archive_markmail:
 
 jira: NUTTX
-wiki: NUTTX
+wiki: confluence/display/NUTTX
 github_project_name: incubator-nuttx
 
 source_repository_os: https://gitbox.apache.org/repos/asf?p=incubator-nuttx.git


### PR DESCRIPTION
## Summary
This updates the Confluence wiki namespace to be the full confluence/display/NUTTX  instead of just NUTTX.  Using just NUTTX use to redirect to the correct url but now redirects to a test wiki.

## Testing
Served the site locally and checked that the link works correctly.
