### PR TITLE
Add logic for publishing documentation from sphinx docs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,6 +42,12 @@ jobs:
         git config --global user.email $email
         ./publish.sh
 
+    - name: Upload artifact of staged site
+      uses: actions/upload-artifact@v2
+      with:
+        name: static-site
+        path: content
+
     - name: Publish Site
       if: (github.event_name == 'push' || github.event_name == 'repository_dispatch' || github.event_name == 'workflow_dispatch' ) && github.ref == 'refs/heads/master'
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,9 @@
 name: CI
 
 on:
+  repository_dispatch:
+    types: docs
+  workflow_dispatch:
   pull_request:
   push:
     branches:
@@ -13,6 +16,17 @@ jobs:
     - uses: actions/checkout@v2
     - run: |
         git fetch --prune --unshallow
+
+    - name: Checkout NuttX Documentation
+      uses: actions/checkout@v2
+      with:
+        repository: apache/incubator-nuttx
+        fetch-depth: 1
+        ref: master
+        path: nuttx/master
+    - uses: ammaraskar/sphinx-action@master
+      with:
+        docs-folder: "nuttx/master/Documentation/"
 
     - name: Install tools
       run: |
@@ -29,6 +43,6 @@ jobs:
         ./publish.sh
 
     - name: Publish Site
-      if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+      if: (github.event_name == 'push' || github.event_name == 'repository_dispatch' || github.event_name == 'workflow_dispatch' ) && github.ref == 'refs/heads/master'
       run: |
         git push origin asf-site:asf-site

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ target
 vendor
 
 .bundle
+
+# NuttX documentation
+nuttx/

--- a/_config.yml
+++ b/_config.yml
@@ -19,7 +19,7 @@ excerpt_separator: ""
 
 repository: https://github.com/apache/apache-website-template
 destination: target
-exclude: [README.md,Gemfile*,vendor]
+exclude: [README.md,Gemfile*,vendor,nuttx]
 keep_files: [".git", ".svn", "apidocs"]
 
 # The base path where the website is deployed

--- a/_includes/themes/apache/_navigation.html
+++ b/_includes/themes/apache/_navigation.html
@@ -21,6 +21,7 @@
                 <li><a href="{{ site.baseurl }}/community-members">Who we are</a></li>
                </ul>
             </li>
+	    <li><a href="{{ site.baseurl }}/docs/latest">Documentation</a></li>
             <li><a href="{{ site.data.project.source_repository_os_mirror }}">GitHub</a></li>
             <li id="apache">
               <a href="#" data-toggle="dropdown" class="dropdown-toggle">Apache<b class="caret"></b></a>

--- a/index.md
+++ b/index.md
@@ -38,4 +38,4 @@ as fork()).
 
 ## Documentation
 
-Extensive documentation can be found on the project [wiki](https://cwiki.apache.org/{{ site.data.project.wiki }}/Nuttx).
+Extensive documentation can be found [here]({{ site.baseurl }}/docs/latest).

--- a/publish.sh
+++ b/publish.sh
@@ -18,20 +18,28 @@
 
 set -e
 
+echo "Prior to running this make sure that the NuttX repo is checked out"
+echo "to nuttx/master and the documentation html has been generated."
+
 gem install bundler:2.1.2
 bundle config set path 'vendor/bundle'
 bundle install 
 bundle exec jekyll clean --source .
 bundle exec jekyll build --source .
 
-COMMIT_HASH=`git rev-parse HEAD`
+mkdir -p target/docs/
+cp -r nuttx/master/Documentation/_build/html target/docs/latest
+
+COMMIT_HASH_WEB=`git rev-parse HEAD`
+COMMIT_HASH_NUTTX=`git -C nuttx/master rev-parse HEAD`
 git checkout asf-site
 #git pull --rebase
 rm -rf content
 mv target content
 git add content
-echo "Publishing changes from master branch $COMMIT_HASH"
-git commit -a -m "Publishing from $COMMIT_HASH"
+echo "Publishing website master branch $COMMIT_HASH_WEB"
+echo "Publishing docs from NuttX master branch $COMMIT_HASH_WEB"
+git commit -a -m "Publishing web: $COMMIT_HASH_WEB docs: $COMMIT_HASH_NUTTX"
 echo " "
 echo "==================================================================="
 echo "You are now on the asf-site branch with your new changes committed."


### PR DESCRIPTION
## Summary
This is the first step in shipping the documentation from NuttX generated via Sphinx.
There is also a hook that can later be triggered by the NuttX repository when a PR is merged in.

For now this only supports the documentation in "master" we do not yet have a release branch with documentation.   Once we have that we can update this logic to handle multiple documentation revisions.

Also after this is merged there will be a button to force the triggering of the workflow.  This can be used in the meantime to force a re-deploy of the website with new documentation.