### PR TITLE
Docs: Use pipenv to drive CI Sphinx build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,14 @@ jobs:
         fetch-depth: 1
         ref: master
         path: nuttx/master
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.8'
+    - name: Generate requirements.txt file
+      run: |
+        cd nuttx/master/Documentation/
+        pip3 install pipenv
+        pipenv lock -r > requirements.txt
     - uses: ammaraskar/sphinx-action@master
       with:
         docs-folder: "nuttx/master/Documentation/"


### PR DESCRIPTION
## Summary
This brings the website publishing for the docs in line with the changes from this PR https://github.com/apache/incubator-nuttx/pull/1698