### PR TITLE
support publishing versioned docs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,33 +15,53 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout Site
+      uses: actions/checkout@v2
     - run: |
         git fetch --prune --unshallow
 
-    - name: Checkout NuttX Documentation
+    - name: Checkout NuttX repo
       uses: actions/checkout@v2
       with:
         repository: apache/incubator-nuttx
-        fetch-depth: 1
+        fetch-depth: 0
         ref: master
-        path: nuttx/master
+        path: nuttx
     - uses: actions/setup-python@v2
       with:
         python-version: '3.8'
-    - name: Generate requirements.txt file
+    - name: Build docs
       run: |
-        cd nuttx/master/Documentation/
         pip3 install pipenv
-        pipenv lock -r > requirements.txt
-    - uses: ammaraskar/sphinx-action@master
-      with:
-        docs-folder: "nuttx/master/Documentation/"
+        cd nuttx/Documentation
 
-    - name: Install tools
+        DOCDIR=../../docs
+        rm -rf $DOCDIR
+
+        NUTTX_TAGS=$(git tag -l nuttx-10*)
+        export NUTTX_VERSIONS=$(echo $NUTTX_TAGS | sed -r 's|^nuttx-||g')
+        for nuttx_version in $NUTTX_TAGS master; do
+          git checkout -f $nuttx_version
+          pipenv install
+          pipenv clean
+          
+          if [ "$nuttx_version" = "master" ]; then
+            OUTDIR="$DOCDIR/latest"
+         else
+            OUTDIR="$DOCDIR/${nuttx_version#nuttx-}"
+          fi
+
+          pipenv run make html BUILDDIR="$OUTDIR"
+          mv $OUTDIR/html/* $OUTDIR
+          rm -rf $OUTDIR/{html,doctrees}
+        done
+
+        cd ../..
+
+    - name: Install Ruby tools
       run: |
         sudo apt-get -y install rubygems ruby-dev zlib1g-dev
-
+    
     - name: Build Site
       run: |
         export GEM_HOME=$HOME/.gem

--- a/publish.sh
+++ b/publish.sh
@@ -19,7 +19,7 @@
 set -e
 
 echo "Prior to running this make sure that the NuttX repo is checked out"
-echo "to nuttx/master and the documentation html has been generated."
+echo "to nuttx and the documentation html has been generated."
 
 gem install bundler:2.1.2
 bundle config set path 'vendor/bundle'
@@ -27,16 +27,17 @@ bundle install
 bundle exec jekyll clean --source .
 bundle exec jekyll build --source .
 
-mkdir -p target/docs/
-cp -r nuttx/master/Documentation/_build/html target/docs/latest
+rm -rf target/docs
+mv docs target/
 
 COMMIT_HASH_WEB=`git rev-parse HEAD`
-COMMIT_HASH_NUTTX=`git -C nuttx/master rev-parse HEAD`
+COMMIT_HASH_NUTTX=`git -C nuttx rev-parse HEAD`
 git checkout asf-site
 #git pull --rebase
 rm -rf content
 mv target content
 git add content
+git status
 echo "Publishing website master branch $COMMIT_HASH_WEB"
 echo "Publishing docs from NuttX master branch $COMMIT_HASH_WEB"
 git commit -a -m "Publishing web: $COMMIT_HASH_WEB docs: $COMMIT_HASH_NUTTX"


### PR DESCRIPTION
## Summary

Modified the workflow so that it pulls nuttx/ repo and loops for every version that we want to document by checking out each tag and building (using pipenv shell) each time. NUTTX_VERSIONS variable determines which tags we pickup for building. We can refine this later based on what we want to expose.

## Impact

Build

## Testing

CI (checked artifact). Would need to test on live site to confirm.
