### PR TITLE
doc build: fix NUTTX_VERSIONS, ignore RC releases

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,8 +38,8 @@ jobs:
         DOCDIR=../../docs
         rm -rf $DOCDIR
 
-        NUTTX_TAGS=$(git tag -l nuttx-10*)
-        export NUTTX_VERSIONS=$(echo $NUTTX_TAGS | sed -r 's|^nuttx-||g')
+        NUTTX_TAGS=$(git tag -l 'nuttx-10*' | fgrep -v RC)
+        export NUTTX_VERSIONS=$(echo -n $NUTTX_TAGS | sed -r 's|^nuttx-||g' | tr '\n' ',')
         for nuttx_version in $NUTTX_TAGS master; do
           git checkout -f $nuttx_version
           pipenv install


### PR DESCRIPTION
## Summary

This fixes NUTTX_VERSIONS which should have had commas and not spaces between each entry. Also, this now
ignores RC releases. 

## Impact

Documentation build

## Testing

CI
