### PR TITLE
Fixup metadata on 9.1.1 and 10.0.1 release

### DIFF
--- a/_releases/10.0.1.md
+++ b/_releases/10.0.1.md
@@ -11,9 +11,10 @@ artifact-root: "https://downloads.apache.org/incubator/nuttx/10.0.1"
 checksum-root: "https://downloads.apache.org/incubator/nuttx/10.0.1"
 key-file: "https://downloads.apache.org/incubator/nuttx/KEYS"
 
-source-os-dist: - "apache-nuttx-10.0.1-incubating.tar.gz" source-app-dist: -
-    "apache-nuttx-apps-10.0.1-incubating.tar.gz"
-
+source-os-dist:
+  - "apache-nuttx-10.0.1-incubating.tar.gz"
+source-app-dist:
+  - "apache-nuttx-apps-10.0.1-incubating.tar.gz"
 ---
 
 

--- a/_releases/9.1.1.md
+++ b/_releases/9.1.1.md
@@ -11,9 +11,11 @@ artifact-root: "https://downloads.apache.org/incubator/nuttx/9.1.1"
 checksum-root: "https://downloads.apache.org/incubator/nuttx/9.1.1"
 key-file: "https://downloads.apache.org/incubator/nuttx/KEYS"
 
-source-os-dist: - "apache-nuttx-9.1.1-incubating.tar.gz" source-app-dist: -
-    "apache-nuttx-apps-9.1.1-incubating.tar.gz"
 
+source-os-dist:
+  - "apache-nuttx-9.1.1-incubating.tar.gz"
+source-app-dist:
+  - "apache-nuttx-apps-9.1.1-incubating.tar.gz"
 ---
 
 


### PR DESCRIPTION
## Summary
Fixup metadata on 9.1.1 and 10.0.1 release

## Impact
The 10.0.1 and 9.1.1 releases did not show up correctly release list or render with the correct template.
_NOTE_ the 9.1.1 release shows up before the 10.0.1 release in the list because the ordering is done by the date and then some default behaviour.  I don't think this is something that important and we can address it later if we want.
 
## Testing
Rendered the site locally
![image](https://user-images.githubusercontent.com/173245/101664696-02209480-3a01-11eb-9d25-d88532880161.png)
