### PR TITLE
Fix generation of NUTTX_VERSIONS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,8 +38,11 @@ jobs:
         DOCDIR=../../docs
         rm -rf $DOCDIR
 
-        NUTTX_TAGS=$(git tag -l 'nuttx-10*' | fgrep -v RC)
-        export NUTTX_VERSIONS=$(echo -n $NUTTX_TAGS | sed -r 's|^nuttx-||g' | tr '\n' ',')
+        NUTTX_TAGS=$(git tag -l 'nuttx-1?.*' | fgrep -v RC)
+        export NUTTX_VERSIONS=$(echo -n "$NUTTX_TAGS" | sed -r 's|^nuttx-||g' | tr '\n' ',')
+        
+        echo "Building documentation for nuttx: $NUTTX_VERSIONS (and master)"
+
         for nuttx_version in $NUTTX_TAGS master; do
           git checkout -f $nuttx_version
           pipenv install


### PR DESCRIPTION
## Summary

Previous fix (#38) did not seem to fully work as a variable needed to be quoted (this is a difference between sh and bash). I also changed it to look for nuttx-1?.* so it will work for quite some time until we reach nuttx-20.*.

Right now it will offer every tagged release, maybe this does not make much sense and we should only present latest minor version of every tag? We can define this later anyway.

## Impact

Documentation build

## Testing

CI

