### PR TITLE
Update old Apache NuttX release links to archive

### DIFF
--- a/_releases/10.0.0.md
+++ b/_releases/10.0.0.md
@@ -7,8 +7,8 @@ date: 2020-12-03
 summary: >
     Release v10.0.0
 
-artifact-root: "https://downloads.apache.org/incubator/nuttx/10.0.0"
-checksum-root: "https://downloads.apache.org/incubator/nuttx/10.0.0"
+artifact-root: "https://archive.apache.org/dist/incubator/nuttx/10.0.0"
+checksum-root: "https://archive.apache.org/dist/incubator/nuttx/10.0.0"
 key-file: "https://downloads.apache.org/incubator/nuttx/KEYS"
 
 source-os-dist:

--- a/_releases/9.0.0.md
+++ b/_releases/9.0.0.md
@@ -7,8 +7,8 @@ date: 2020-05-11
 summary: >
     Release v9.0.0
 
-artifact-root: "https://downloads.apache.org/incubator/nuttx/9.0.0"
-checksum-root: "https://downloads.apache.org/incubator/nuttx/9.0.0"
+artifact-root: "https://archive.apache.org/dist/incubator/nuttx/9.0.0"
+checksum-root: "https://archive.apache.org/dist/incubator/nuttx/9.0.0"
 key-file: "https://downloads.apache.org/incubator/nuttx/KEYS"
 
 source-os-dist:

--- a/_releases/9.1.0.md
+++ b/_releases/9.1.0.md
@@ -7,8 +7,8 @@ date: 2020-07-22
 summary: >
     Release v9.1.0
 
-artifact-root: "https://downloads.apache.org/incubator/nuttx/9.1.0"
-checksum-root: "https://downloads.apache.org/incubator/nuttx/9.1.0"
+artifact-root: "https://archive.apache.org/dist/incubator/nuttx/9.1.0"
+checksum-root: "https://archive.apache.org/dist/incubator/nuttx/9.1.0"
 key-file: "https://downloads.apache.org/incubator/nuttx/KEYS"
 
 source-os-dist:


### PR DESCRIPTION
## Summary
Update the 9.0.0, 9.1.0, and 10.0.0 releases to point to the archive.

