### PR TITLE
Change https://nuttx.apache.org/download/ to https://www.apache.org/dyn/closer.lua

### DIFF
--- a/_releases/10.0.1.md
+++ b/_releases/10.0.1.md
@@ -7,7 +7,7 @@ date: 2020-12-08
 summary: >
     Release v10.0.1
 
-artifact-root: "https://downloads.apache.org/incubator/nuttx/10.0.1"
+artifact-root: "https://www.apache.org/dyn/closer.lua/incubator/nuttx/10.0.1"
 checksum-root: "https://downloads.apache.org/incubator/nuttx/10.0.1"
 key-file: "https://downloads.apache.org/incubator/nuttx/KEYS"
 

--- a/_releases/10.1.0.md
+++ b/_releases/10.1.0.md
@@ -7,7 +7,7 @@ date: 2021-5-26
 summary: >
     Release v10.1.0
 
-artifact-root: "https://downloads.apache.org/incubator/nuttx/10.1.0"
+artifact-root: "https://www.apache.org/dyn/closer.lua/incubator/nuttx/10.1.0"
 checksum-root: "https://downloads.apache.org/incubator/nuttx/10.1.0"
 key-file: "https://downloads.apache.org/incubator/nuttx/KEYS"
 

--- a/_releases/9.0.0.md
+++ b/_releases/9.0.0.md
@@ -47,7 +47,7 @@ This is the first release of NuttX as Apache NuttX (Incubating) and represents o
 
 Note that release consists of two tarballs:  apache-nuttx-9.0.0-incubating.tar.gz and apache-nuttx-apps-9.0.0-incubating.tar.gz.  These are available from:
 
-    https://downloads.apache.org/incubator/nuttx/9.0.0/
+    https://www.apache.org/dyn/closer.lua/incubator/nuttx/9.0.0/
 
 Both may be needed (see the top-level nuttx/README.txt file for build
 information).  SHA512 checksums:

--- a/_releases/9.1.0.md
+++ b/_releases/9.1.0.md
@@ -47,7 +47,7 @@ This is the second release of NuttX as Apache NuttX (Incubating).
 
 Note that release consists of two tarballs:  apache-nuttx-9.1.0-incubating.tar.gz and apache-nuttx-apps-9.1.0-incubating.tar.gz.  These are available from:
 
-    https://downloads.apache.org/incubator/nuttx/9.1.0/
+    https://www.apache.org/dyn/closer.lua/incubator/nuttx/9.1.0/
 
 Both may be needed (see the top-level nuttx/README.txt file for build
 information).  SHA512 checksums:

--- a/_releases/9.1.1.md
+++ b/_releases/9.1.1.md
@@ -7,7 +7,7 @@ date: 2020-12-08
 summary: >
     Release v9.1.1
 
-artifact-root: "https://downloads.apache.org/incubator/nuttx/9.1.1"
+artifact-root: "https://www.apache.org/dyn/closer.lua/incubator/nuttx/9.1.1"
 checksum-root: "https://downloads.apache.org/incubator/nuttx/9.1.1"
 key-file: "https://downloads.apache.org/incubator/nuttx/KEYS"
 


### PR DESCRIPTION
## Summary
follow the new requirements from the mentor.

## Impact
The download link is difference.

## Testing

