### PR TITLE
Add link to Apache Software Foundation's Privacy Policy

### DIFF
--- a/_includes/themes/apache/_navigation.html
+++ b/_includes/themes/apache/_navigation.html
@@ -29,6 +29,7 @@
                 <li><a href="http://www.apache.org/foundation/how-it-works.html">Apache Software Foundation</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li><a href="http://www.apache.org/security/">Security</a></li>
+                <li><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy</a></li>
                 <li><a href="http://www.apache.org/events/current-event">Events</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>


### PR DESCRIPTION
## Summary

Add link to Apache.org Privacy Policy.

All projects are required to link to the Privacy Policy. See https://www.apache.org/foundation/marks/pmcs.html#navigation

## Impact

Lack of the link to the Privacy Policy is preventing NuttX graduation to Top-Level-Project. See https://lists.apache.org/thread/wwmqtk3s2tscv9qj20w3c2rov6f34kjn

## Testing

N/A