### PR TITLE
Use master for build deps for docs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,6 +35,11 @@ jobs:
         pip3 install pipenv
         cd nuttx/Documentation
 
+        # For now install only dependencies from master for all versions
+        # of documentation so far old versions can use these updated pin
+        # but the old pins in old releases cannot always be used.
+        pipenv install
+
         DOCDIR=../../docs
         rm -rf $DOCDIR
 
@@ -45,8 +50,6 @@ jobs:
 
         for nuttx_version in $NUTTX_TAGS master; do
           git checkout -f $nuttx_version
-          pipenv install
-          pipenv clean
           
           if [ "$nuttx_version" = "master" ]; then
             OUTDIR="$DOCDIR/latest"


### PR DESCRIPTION
## Summary
There is an issue where some of the old tags cannot be build using the dependencies in those tags.  Instead build all tags from the dependencies defined in master. We can revisit if this breaks in the future.

## Impact
Webpage should be able to be built again from CI.

## Testing
This PR passing.
