### PR TITLE
Contributors list update after graduation PPMC->PMC, retain IPMC status.

### DIFF
--- a/_data/contributors.yml
+++ b/_data/contributors.yml
@@ -21,7 +21,7 @@
 - name: Abdelatif Guettouche
   apacheId: aguettouche
   githubId: Ouss4
-  role: PMC, PPMC, Committer
+  role: PMC, Committer
   org:
 
 - name: Adam Feuer
@@ -33,25 +33,25 @@
 - name: Alan Carvalho de Assis
   apacheId: acassis
   githubId: acassis
-  role: PMC, PPMC, Committer
+  role: PMC, Committer
   org:
 
 - name: Alin Jerpelea
   apacheId: jerpelea
   githubId: jerpelea
-  role: PMC, PPMC, Committer
+  role: PMC, Committer
   org:
 
 - name: Anthony Merlino
   apacheId: antmerlino
   githubId: antmerlino
-  role: PMC, PPMC, Committer
+  role: PMC, Committer
   org:
 
 - name: Brennan Ashton
   apacheId: btashton
   githubId: btashton
-  role: PMC, PPMC, Committer
+  role: PMC, Committer
   org:
 
 - name: Chao An
@@ -63,25 +63,25 @@
 - name: David Sidrane
   apacheId: davids5
   githubId: davids5
-  role: PMC, PPMC, Committer
+  role: PMC, Committer
   org:
 
 - name: Duo Zhang
   apacheId: zhangduo
   githubId: Apache9
-  role: Mentor, PMC, IPMC, PPMC, Committer
+  role: Mentor, PMC, IPMC, Committer
   org:
 
 - name:	Flavio Paiva Junqueira
   apacheId: fpj
   githubId: fpj
-  role: Mentor, PMC, IPMC, PPMC, Committer
+  role: Mentor, PMC, IPMC, Committer
   org:
 
 - name: Gregory Nutt
   apacheId: gnutt
   githubId: patacongo
-  role: PMC, PPMC, Committer
+  role: PMC, Committer
   org:
 
 - name: Gustavo Henrique Nihei
@@ -104,19 +104,19 @@
 - name: Justin Mclean
   apacheId: jmclean
   githubId: justinmclean
-  role: Mentor, PMC, IPMC, PPMC, Committer
+  role: Mentor, PMC, IPMC, Committer
   org:
 
 - name: Junping Du
   apacheId: junping_du
   githubId: JunpingDu
-  role: Champion, Mentor, PMC, IPMC, PPMC, Committer
+  role: Champion, Mentor, PMC, IPMC, Committer
   org:
 
 - name: Masayuki Ishikawa
   apacheId: masayuki
   githubId: masayuki2009
-  role: PMC, PPMC, Committer
+  role: PMC, Committer
   org:
 
 - name: Mateusz Szafoni
@@ -134,13 +134,13 @@
 - name: Mohammad Asif Siddiqui
   apacheId: asifdxtreme
   githubId: asifdxtreme
-  role: Mentor, PMC, IPMC, PPMC, Committer
+  role: Mentor, PMC, IPMC, Committer
   org:
 
 - name: Nathan Hartman
   apacheId: hartmannathan
   githubId: hartmannathan
-  role: PMC, PPMC, Committer
+  role: PMC, Committer
   org:
 
 - name: Petro Karashchenko
@@ -152,7 +152,7 @@
 - name: Sara da Cunha Monteiro de Souza
   apacheId: sara
   githubId: saramonteiro
-  role: PMC, PPMC, Committer
+  role: PMC, Committer
   org:
 
 - name: Sebastian Ene
@@ -170,7 +170,7 @@
 - name: Xiang Xiao
   apacheId: xiaoxiang
   githubId: xiaoxiang781216
-  role: PMC, PPMC, Committer
+  role: PMC, Committer
   org:
 
 - name: Yamamoto Takashi


### PR DESCRIPTION
## Summary
* Contributors list update after graduation PPMC->PMC, retain IPMC status.
* As instructed by @patacongo in https://github.com/apache/nuttx-website/pull/92 PPMC becomes PMC after graduation, IPMC status is retained.

## Impact
* Update PMC status on the Contributors page after graduation.

## Testing
* Please verify :-)
