### PR TITLE
Add "jekyll" label to .asf.yaml

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -13,6 +13,7 @@ github:
     - real-time
     - mcu
     - microcontroller
+    - jekyll
   enabled_merge_buttons:
     # disable squash button:
     squash:  false


### PR DESCRIPTION
## Summary
Adding the **_jekyll_** label so that its easier to find ASF projects using [Jekyll](https://jekyllrb.com/)

(I've created an [Infra PR](https://github.com/apache/infrastructure-website/pull/255) to add [this GitHub Query](https://github.com/search?q=topic%3Ajekyll+org%3Aapache&type=Repositories) to the [Infra Project Website page](https://infra.apache.org/project-site.html#sitemanagement))

## Impact
Only on GitHub appearance

## Testing
N/A
