### PR TITLE
contributors: Add Michal Lenc as Contributor and PMC member.

### DIFF
--- a/_data/contributors.yml
+++ b/_data/contributors.yml
@@ -155,6 +155,12 @@
   role: PMC, Committer
   org:
 
+- name: Michal Lenc
+  apacheId: michallenc
+  githubId: michallenc
+  role: PMC, Committer
+  org: Elektroline a.s
+
 - name: Mohammad Asif Siddiqui
   apacheId: asifdxtreme
   githubId: asifdxtreme


### PR DESCRIPTION
Michal Lenc @michallenc becomes Contributor and PMC member. Congratulations! :-)