### PR TITLE
ssltestgen: Add script to generate local test ssl key+crt.

### DIFF
--- a/ssltestgen.sh
+++ b/ssltestgen.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to you under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This script genrates local testing SSL key and certificate using openssl.
+# Enter key password (used to sign crt and launch srv) and cert details.
+# Then: bundle exec jekyll serve --ssl-cert server.crt --ssl-key server.key
+
+set -e
+
+openssl genrsa -des3 -out server.key 1024
+openssl req -new -key server.key -out server.csr
+openssl x509 -req -days 3650 -in server.csr -signkey server.key -out server.crt


### PR DESCRIPTION
## Summary

* Sometimes a HTTPS version of the site needs to be tested locally before PR is submitted (i.e. to detect HTTP hardcoded links and/or components from external sites ).
* This script genrates local testing SSL key and certificate using openssl. No external tools or sites needs to be used.
* Enter key password (used to sign crt and launch srv) and cert details. Then: `bundle exec jekyll serve --ssl-cert server.crt --ssl-key server.key`.

## Impact

* Only local testing when HTTPS/SSL also needs to be tested this script provides quickest possible way to generate self-signed certificate locally.
* No external tools or sites needs to be used.

## Testing

Tested on FreeBSD 14.3:

1. Generate ssl server.key + server.crt:

```
% ./ssltestgen.sh
Enter PEM pass phrase:
Verifying - Enter PEM pass phrase:
Enter pass phrase for server.key:
You are about to be asked to enter information that will be incorporated
into your certificate request.
What you are about to enter is what is called a Distinguished Name or a DN.
There are quite a few fields but you can leave some blank
For some fields there will be a default value,
If you enter '.', the field will be left blank.
-----
Country Name (2 letter code) [AU]:PL
State or Province Name (full name) [Some-State]:WAW
Locality Name (eg, city) []:WAW
Organization Name (eg, company) [Internet Widgits Pty Ltd]:CeDeROM
Organizational Unit Name (eg, section) []:R&D
Common Name (e.g. server FQDN or YOUR name) []:localhost
Email Address []:

Please enter the following 'extra' attributes
to be sent with your certificate request
A challenge password []:
An optional company name []:
Enter pass phrase for server.key:
Certificate request self-signature ok
subject=C = PL, ST = WAW, L = WAW, O = CeDeROM, OU = R&D, CN = localhost
```

2. Start local Jekyll with ssl:

```
% bundle exec jekyll serve --ssl-cert server.crt --ssl-key server.key
(..)
Enter PEM pass phrase:
    Server address: https://127.0.0.1:4000
  Server running... press ctrl-c to stop.
```