### PR TITLE
workflows/main.yml: bump actions and fix build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,18 +16,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Site
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - run: |
         git fetch --prune --unshallow
 
     - name: Checkout NuttX repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: apache/nuttx
         fetch-depth: 0
         ref: master
         path: nuttx
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v4
       with:
         python-version: '3.8'
     - name: Build docs
@@ -36,6 +36,9 @@ jobs:
         echo " Install Pipenv"
         echo "======================================================="
 
+        python3 -m venv .venv
+        source .venv/bin/activate
+        export PIPENV_VERBOSITY=-1
         pip3 install pipenv
 
         echo "======================================================="
@@ -90,8 +93,8 @@ jobs:
 
           echo " ====> PIPENV CLEANUP."
 
-          # Uninstall pipenv packages (cached packages are preserved).
-          pipenv uninstall --all
+          # Clear caches (pipenv, pip)
+          pipenv --clear install
 
         done
 
@@ -103,7 +106,7 @@ jobs:
     - name: Install Ruby tools
       run: |
         sudo apt-get -y install rubygems ruby-dev zlib1g-dev
-    
+
     - name: Build Site
       run: |
         export GEM_HOME=$HOME/.gem
@@ -115,7 +118,7 @@ jobs:
         ./publish.sh
 
     - name: Upload artifact of staged site
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: static-site
         path: content


### PR DESCRIPTION
## Summary


![doc](https://github.com/user-attachments/assets/51e704b4-d8c3-4ba6-85e6-600a314ccd91)


-fix
  Extension error:
 Could not import extension sphinx.builders.linkcheck (exception: No module named 'urllib3')
 make: *** [Makefile:48: html] Error 2
 Error: Process completed with exit code 2.

https://github.com/apache/nuttx-website/actions/runs/20355397862/job/58489650919#logs

-bump
 actions/checkout@v4 -> v6
 actions/upload-artifact@v4 -> v5

## Impact
fix build NuttX documentation

## Testing
CI
