### PR TITLE
Make footer year dynamic using Jekyll build time

### DIFF
--- a/_includes/themes/apache/footer.html
+++ b/_includes/themes/apache/footer.html
@@ -7,7 +7,7 @@
                                                       alt="Logo of the Apache Software Foundation"/></a>
                 </div>
                 <div>
-                    Copyright &copy; 2019-2025 <a href="https://www.apache.org">The Apache Software Foundation</a>.
+                    Copyright &copy; 2019-{{ site.time | date: "%Y" }} <a href="https://www.apache.org">The Apache Software Foundation</a>.
                     Licensed under the <a href="https://www.apache.org/licenses/LICENSE-2.0">Apache License, Version
                     2.0</a>.
                     <br>


### PR DESCRIPTION
This PR improves the footer year display by making it dynamic instead of hard-coded. The footer now automatically renders the current year at build time using `{{ site.time | date: "%Y" }`}, ensuring it always stays up to date without manual edits. This makes the footer more robust and prevents outdated year information in future releases.