### PR TITLE
Fix: Convert HTTP to HTTPS and fix APPS link in navigation

### DIFF
--- a/_data/project.yml
+++ b/_data/project.yml
@@ -28,7 +28,7 @@ latest_release: 12.12.0
 dev_list: dev@nuttx.apache.org
 dev_list_subscribe: dev-subscribe@nuttx.apache.org
 dev_list_unsubscribe: dev-unsubscribe@nuttx.apache.org
-dev_list_archive: http://mail-archives.apache.org/mod_mbox/nuttx-dev/
+dev_list_archive: https://mail-archives.apache.org/mod_mbox/nuttx-dev/
 dev_list_archive_mailarchive: https://www.mail-archive.com/dev@nuttx.apache.org/
 dev_list_archive_markmail:
 
@@ -42,7 +42,7 @@ user_list_archive_markmail:
 commits_list: commits@nuttx.apache.org
 commits_list_subscribe: commits-subscribe@nuttx.apache.org
 commits_list_unsubscribe: commits-unsubscribe@nuttx.apache.org
-commits_list_archive: http://mail-archives.apache.org/mod_mbox/nuttx-commits/
+commits_list_archive: https://mail-archives.apache.org/mod_mbox/nuttx-commits/
 commits_list_archive_mailarchive: https://www.mail-archive.com/commits@nuttx.apache.org/
 commits_list_archive_markmail:
 

--- a/_includes/themes/apache/_navigation.html
+++ b/_includes/themes/apache/_navigation.html
@@ -35,7 +35,7 @@
                <ul class="dropdown-menu dropdown-left">
                 <li><a href="{{ site.data.project.download }}">Releases</a></li>
                 <li><a href="{{ site.data.project.source_repository_os_mirror }}">RTOS source code</a></li>
-                <li><a href="{{ site.data.project.source_repository_os_mirror }}">APPS source code</a></li>
+                <li><a href="{{ site.data.project.source_repository_apps_mirror }}">APPS source code</a></li>
               </ul>
             </li>
             <li id="apache">


### PR DESCRIPTION
### PR UPDATE
- Change dev_list_archive from http to https (line 31)
- Change commits_list_archive from http to https (line 45)
- Fix APPS source code link to point to nuttx-apps repository instead of nuttx repository

