### PR TITLE
Fix typos and Contributing link

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ for `x86_64-linux`, `Darwin`, `FreeBSD`, and other build hosts with
 `bundle lock --add-platform <your_platform>` command.
 
 
-## Updating the Documentaion
+## Updating the Documentation
 
 NuttX Technical Documentation is part of the
 [NuttX source code repository](https://github.com/apache/nuttx/tree/master/Documentation).

--- a/community.md
+++ b/community.md
@@ -36,7 +36,7 @@ You can:
 * Report bugs and submit patches.
 * Contribute code or documentation.
 
-Visit the [Contributing] page for more information.
+Visit the [Contributing](https://nuttx.apache.org/docs/latest/contributing/index.html) page for more information.
 
 
 ### Mailing list


### PR DESCRIPTION
### This pull request fixes minor documentation issues and improves navigation.

- Corrected a typo in README.md (“Documentaion” → “Documentation”).
- Updated the Contributing reference in community.md to point to the correct page: https://nuttx.apache.org/docs/latest/contributing/index.html

No functional changes - documentation only.