### PR TITLE
Support plantuml in documentation build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,6 +40,13 @@ jobs:
         source .venv/bin/activate
         export PIPENV_VERBOSITY=-1
         pip3 install pipenv
+        
+        echo "======================================================="
+        echo " Install PlantUML"
+        echo "======================================================="
+
+        sudo apt update
+        sudo apt install plantuml
 
         echo "======================================================="
         echo " Setup nuttx/Documentation"


### PR DESCRIPTION
## Summary

Include installation of PlantUML as a pre-cursor to building the documentation. Allows for support of PlantUML syntax to render UML diagrams in the docs, as part of https://github.com/apache/nuttx/pull/18379

## Impact

PlantUML syntax can be used in documentation to render UML diagrams.

## Testing

See https://github.com/apache/nuttx/pull/18379