### PR TITLE
_data/contributors.yml: remove Michal Lenc and Gregory Nutt as PMCs

### DIFF
--- a/_data/contributors.yml
+++ b/_data/contributors.yml
@@ -81,7 +81,7 @@
 - name: Gregory Nutt
   apacheId: gnutt
   githubId: patacongo
-  role: PMC, Committer
+  role: Committer
   org:
 
 - name: Guiding Li
@@ -158,7 +158,7 @@
 - name: Michal Lenc
   apacheId: michallenc
   githubId: michallenc
-  role: PMC, Committer
+  role: Committer
   org: Elektroline a.s
 
 - name: Mohammad Asif Siddiqui


### PR DESCRIPTION
## Summary
Michal Lenc was incorrectly listed as a PMC member and Gregory Nutt resigned from being PMC.